### PR TITLE
Show available methods instead of "endpoint" when autocompleting

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/annotator/RestSdkAnnotator.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/annotator/RestSdkAnnotator.java
@@ -52,8 +52,8 @@ public class RestSdkAnnotator implements Annotator {
             return;
           WebApi webApi = (WebApi) webApiDocument.encodes();
           var endpoint = RestSdkHelper.endpointByPath(webApi, endpointPath);
-          if (endpoint != null && endpoint.operations().stream().map(o -> o.method().value()).noneMatch(m -> m.equals(httpMethod)))
-            holder.newAnnotation(HighlightSeverity.ERROR, "There no " + httpMethod + " method in endpoint " + endpointPath)
+          if (endpoint != null && RestSdkHelper.getEndpointMethods(endpoint).noneMatch(m -> m.equals(httpMethod)))
+            holder.newAnnotation(HighlightSeverity.ERROR, "There´s no " + httpMethod + " method in endpoint " + endpointPath)
                     .range(element)
                     .create();
         }

--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/completion/RestSdkCompletionService.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/completion/RestSdkCompletionService.java
@@ -152,7 +152,7 @@ public class RestSdkCompletionService {
       assert operationsKeyValue != null;
       final EndPoint endPoint = RestSdkHelper.endpointByPath(webApi, ((YAMLKeyValue) operationsKeyValue.getParent().getParent()).getKeyText());
       List<String> methods = endPoint != null
-              ? endPoint.operations().stream().map(operation -> operation.method().value()).collect(Collectors.toList())
+              ? RestSdkHelper.getEndpointMethods(endPoint).collect(Collectors.toList())
               : ALL_HTTP_METHODS;
       var methodsMapping = operationsKeyValue.getValue();
       methods.forEach(method -> {

--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/reference/ApiPathReference.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/reference/ApiPathReference.java
@@ -19,6 +19,7 @@ import org.mule.tooling.restsdk.utils.RestSdkHelper;
 import org.mule.tooling.restsdk.utils.SelectionPath;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ApiPathReference extends PsiReferenceBase<PsiElement> {
 
@@ -41,10 +42,12 @@ public class ApiPathReference extends PsiReferenceBase<PsiElement> {
     final WebApi webApi = (WebApi) webApiDocument.encodes();
     List<EndPoint> endPoints = webApi.endPoints();
     LookupElementBuilder[] result = new LookupElementBuilder[endPoints.size()];
-    for (int i = 0; i < endPoints.size(); i++)
-      result[i] = LookupElementBuilder.create(endPoints.get(i).path().value())
-              .withTypeText("endpoint", true)
+    for (int i = 0; i < endPoints.size(); i++) {
+      EndPoint endPoint = endPoints.get(i);
+      result[i] = LookupElementBuilder.create(endPoint.path().value())
+              .withTypeText(RestSdkHelper.getEndpointMethods(endPoint).collect(Collectors.joining(", ")), true)
               .withIcon(AllIcons.Vcs.BranchNode);
+    }
     return result;
   }
 

--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/RestSdkHelper.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/RestSdkHelper.java
@@ -284,6 +284,16 @@ public class RestSdkHelper {
             .distinct();
   }
 
+  /** Returns a stream with the methods supported by an endpoint.
+   *
+   * @param endPoint the endpoint
+   * @return a stream of method names
+   */
+  @Contract(pure = true)
+  public static @NotNull Stream<String> getEndpointMethods(@NotNull EndPoint endPoint) {
+    return endPoint.operations().stream().map(o -> o.method().value());
+  }
+
   /** Gets the Rest SDK "kind" value for an API security scheme.
    */
   @Contract(pure = true)


### PR DESCRIPTION
Also, added a method to get a Stream of methods from a given endpoint.

Fixed an error message shown by the annotator when an inexistant method is referenced.