### PR TITLE
API loading fixes

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/IntellijResourceLoader.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/IntellijResourceLoader.java
@@ -1,0 +1,65 @@
+package org.mule.tooling.restsdk.utils;
+
+import amf.core.client.common.remote.Content;
+import amf.core.client.platform.resource.LoaderWithExecutionContext;
+import amf.core.client.platform.resource.ResourceLoader;
+import amf.core.internal.remote.JvmPlatform;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import scala.compat.java8.FutureConverters;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+
+import java.io.FileNotFoundException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An AMF {@link ResourceLoader} that uses IntelliJ APIs to load files.
+ * <p>
+ * Using IntelliJ APIs provides caching (and the in-memory file text is shared with the IDE), applies
+ * the project config while converting to text and supports the temp: scheme that appears on tests.
+ */
+public class IntellijResourceLoader implements ResourceLoader, LoaderWithExecutionContext {
+    private final ExecutionContext executionContext;
+
+    public IntellijResourceLoader(ExecutionContext executionContext) {
+        this.executionContext = executionContext;
+    }
+
+    @Override
+    public CompletableFuture<Content> fetch(String resource) {
+        Future<Content> future = Future.apply(() -> {
+            String text = ReadAction.compute(() -> {
+                VirtualFile virtualFile = VirtualFileManager.getInstance().findFileByUrl(resource);
+                if (virtualFile == null)
+                    throw new RuntimeException(new FileNotFoundException(resource));
+                Document document = FileDocumentManager.getInstance().getDocument(virtualFile);
+                if (document == null)
+                    throw new RuntimeException("Couldn't get document for " + resource);
+                return document.getText();
+            });
+            return new Content(text, ensureFileAuthority(resource),
+                    JvmPlatform.instance().extension(resource)
+                            .flatMap(ext -> JvmPlatform.instance().mimeFromExtension(ext)));
+        }, executionContext);
+        return FutureConverters.toJava(future).toCompletableFuture();
+    }
+
+    @Override
+    public boolean accepts(String resource) {
+        String protocol = VirtualFileManager.extractProtocol(resource);
+        return VirtualFileManager.getInstance().getFileSystem(protocol) != null;
+    }
+
+    private String ensureFileAuthority(String str) {
+        return str.matches("[a-z]+:.*") ? str : "file://" + str;
+    }
+
+    @Override
+    public ResourceLoader withExecutionContext(ExecutionContext ec) {
+        return new IntellijResourceLoader(ec);
+    }
+}

--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/RestSdkHelper.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/RestSdkHelper.java
@@ -1,6 +1,7 @@
 package org.mule.tooling.restsdk.utils;
 
 import amf.apicontract.client.platform.AMFBaseUnitClient;
+import amf.apicontract.client.platform.AMFConfiguration;
 import amf.apicontract.client.platform.WebAPIConfiguration;
 import amf.apicontract.client.platform.model.domain.EndPoint;
 import amf.apicontract.client.platform.model.domain.Operation;
@@ -16,6 +17,7 @@ import amf.core.client.platform.model.domain.DataNode;
 import amf.core.client.platform.model.domain.DomainElement;
 import amf.core.client.platform.model.domain.RecursiveShape;
 import amf.core.client.platform.model.domain.Shape;
+import amf.core.client.platform.resource.ResourceLoader;
 import amf.core.client.scala.model.DataType;
 import amf.shapes.client.platform.model.domain.*;
 import com.intellij.openapi.diagnostic.Logger;
@@ -118,7 +120,9 @@ public class RestSdkHelper {
   @Nullable
   private static Document parseWebApi(VirtualFile child) {
     long before = System.nanoTime();
-    final AMFBaseUnitClient client = WebAPIConfiguration.WebAPI().baseUnitClient();
+    AMFConfiguration amfConfiguration = WebAPIConfiguration.WebAPI();
+    ResourceLoader rl = new IntellijResourceLoader(amfConfiguration.getExecutionContext());
+    final AMFBaseUnitClient client = amfConfiguration.withResourceLoader(rl).baseUnitClient();
     final AMFParseResult parseResult;
     try {
       parseResult = client.parse(child.getUrl()).get();


### PR DESCRIPTION
- Have AMF use IntelliJ APIs to load the specs. This seems necessary for loading APIs from tests.
- Prevent leaking a PsiFile.

I think this PR should not be "squashed", since it contains two separate modifications described in their commits. Thanks!