### PR TITLE
Check uriParameter in triggers' bindings

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/RestSdkPaths.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/utils/RestSdkPaths.java
@@ -79,6 +79,7 @@ public class RestSdkPaths {
 
   public static final SelectionPath RELATIVE_TRIGGER_METHOD_FROM_BINDING_BODY_PATH = SelectionPath.PARENT.parent().parent().parent().child(METHOD);
   public static final SelectionPath RELATIVE_TRIGGER_PATH_FROM_BINDING_BODY_PATH = SelectionPath.PARENT.parent().parent().parent().child(PATH);
+  public static final SelectionPath RELATIVE_TRIGGER_PATH_FROM_BINDING_URIPARAMETER_PATH = SelectionPath.PARENT.parent().parent().child(PATH);
 
 
   public static final SelectionPath


### PR DESCRIPTION
If a trigger's binding uriParameter is not present in the endpoint path, show an error.