### PR TITLE
Generator tool: Endpoint sorting is lost due to the use of HashMap

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/generation/BulkEndpointOperationsGeneratorDialog.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/restsdk/generation/BulkEndpointOperationsGeneratorDialog.java
@@ -192,7 +192,7 @@ public class BulkEndpointOperationsGeneratorDialog extends DialogWrapper {
                 return "";
             }
             return path.substring(start, end);
-        }));
+        }, LinkedHashMap::new, Collectors.toList()));
         if (m.size() == 1) {
             String k = m.keySet().iterator().next();
             if (!k.isBlank()) {


### PR DESCRIPTION
Generator tool: Endpoint sorting is lost due to the use of HashMap. Use LinkedHashMap instead.