### PR TITLE
Fixed a few bugs

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/preview/PreviewToolWindowPanel.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/preview/PreviewToolWindowPanel.java
@@ -140,6 +140,8 @@ public class PreviewToolWindowPanel extends SimpleToolWindowPanel implements Dis
   private void setFile(@Nullable PsiFile psiFile) {
     if (psiFile == null) {
       cardLayout.show(mainPanel, NOTHING_TO_SHOW);
+      // Dispose the wavePreviewComponent when dwl file is closed, so that the component can open when dwl is reopened
+      weavePreviewComponent.dispose();
     } else if (psiFile != weavePreviewComponent.getCurrentFile() && psiFile.getFileType() == WeaveFileType.getInstance()) {
       WeaveDocument weaveDocument = WeavePsiUtils.getWeaveDocument(psiFile);
       if (weaveDocument != null && weaveDocument.isMappingDocument()) {

--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/service/WeaveRuntimeService.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/service/WeaveRuntimeService.java
@@ -200,7 +200,8 @@ public final class WeaveRuntimeService implements Disposable {
 
     @NotNull
     private String getTestFolderName(WeaveDocument weaveDocument) {
-        return weaveDocument.getQualifiedName().replaceAll("::", "-");
+        // Replace directory separator with a "-".  Support Mac, Unix and Windows directory separators
+        return weaveDocument.getQualifiedName().replaceAll("::|/|\\\\", "-");
     }
 
     @Nullable

--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/service/agent/WeaveAgentService.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/service/agent/WeaveAgentService.java
@@ -524,6 +524,12 @@ public final class WeaveAgentService implements Disposable {
                 // parametersList.add("--agent");
                 parametersList.add("-p");
                 parametersList.add(String.valueOf(freePort));
+
+                // Force use of dynamic classpath.  In Windows, a large project will cause the agent fail to start due
+                // to a very large classpath line in the command line.
+                //noinspection MissingRecentApi
+                params.useDynamicClasspathDefinedByJdkLevel();
+
                 return params;
             }
 


### PR DESCRIPTION
Fixed a few bugs:
1. Cannot create scenarios if dwl file is in a sub directory on Windows
2. Dataweave preview window fails to open if a dwl file is closed and reopened.  Switching to a different dwl file brings back the preview window.  Fixed by disposing the preview when dwl file is closed.
3. Force to use dynamic classpath to avoid agent not starting up due to classpath string being too large on Windows.  This fix will break on earlier versions of the IDE though.