### PR TITLE
Fixed module path separator in Windows

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/util/VirtualFileSystemUtils.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/util/VirtualFileSystemUtils.java
@@ -127,7 +127,7 @@ public class VirtualFileSystemUtils {
     public static NameIdentifier getNameIdentifierWithRelative(VirtualFile vfs, VirtualFile contentRootForFile) {
         final String relPath = VfsUtil.getRelativePath(vfs, contentRootForFile);
         if (relPath != null) {
-            return NameIdentifierHelper.fromWeaveFilePath(FileSystems.getDefault().getSeparator().equals("\\") ? relPath.replace("/", "\\") : relPath);
+            return NameIdentifierHelper.fromWeaveFilePath(relPath, FileSystems.getDefault().getSeparator());
         } else {
             return NameIdentifierHelper.fromWeaveFilePath(contentRootForFile.getPath());
         }

--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/util/VirtualFileSystemUtils.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/util/VirtualFileSystemUtils.java
@@ -24,6 +24,7 @@ import org.mule.weave.v2.parser.ast.variables.NameIdentifier;
 import org.mule.weave.v2.sdk.NameIdentifierHelper;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -126,7 +127,7 @@ public class VirtualFileSystemUtils {
     public static NameIdentifier getNameIdentifierWithRelative(VirtualFile vfs, VirtualFile contentRootForFile) {
         final String relPath = VfsUtil.getRelativePath(vfs, contentRootForFile);
         if (relPath != null) {
-            return NameIdentifierHelper.fromWeaveFilePath(relPath);
+            return NameIdentifierHelper.fromWeaveFilePath(FileSystems.getDefault().getSeparator().equals("\\") ? relPath.replace("/", "\\") : relPath);
         } else {
             return NameIdentifierHelper.fromWeaveFilePath(contentRootForFile.getPath());
         }


### PR DESCRIPTION
Module path separator in Windows is currently "/" ie: dw/util/Math, which is incorrect.  It should be "::" (ie: dw::util::Math).  This is because Intellij's virtual file uses "/" separator, but Dataweave parser SDK expects the native file separator, which is "\" in Windows.

Pre-correcting the file separator before sending the path to the parser SDK fixes this issue.

This bug caused modules and some functions as being not resolvable in the editor. Also, the auto suggest gives the wrong path (ie: suggesting dw/util/Math instead of dw::util::Math).