### PR TITLE
Fixed plugin crash and add libraries

### DIFF
--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/preview/PreviewToolWindowPanel.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/preview/PreviewToolWindowPanel.java
@@ -150,6 +150,7 @@ public class PreviewToolWindowPanel extends SimpleToolWindowPanel implements Dis
           mainPanel.remove(previewComponent);
           previewComponent = null;
         }
+        weavePreviewComponent = new WeavePreviewComponent(myProject);
         previewComponent = weavePreviewComponent.createComponent();
         mainPanel.add(previewComponent, PREVIEW_EDITOR);
         weavePreviewComponent.open(psiFile);

--- a/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/service/agent/WeaveAgentService.java
+++ b/data-weave-plugin/src/main/java/org/mule/tooling/lang/dw/service/agent/WeaveAgentService.java
@@ -338,10 +338,11 @@ public final class WeaveAgentService implements Disposable {
     }
 
     public void loadClasspathInto(Module module, PathsList pathsList) {
-        final OrderEnumerator orderEnumerator = OrderEnumerator.orderEntries(module).withoutLibraries().withoutSdk();
+        final OrderEnumerator orderEnumerator = OrderEnumerator.orderEntries(module).withoutSdk();
         //We add sources too as we don't compile the we want to have the weave files up to date
         pathsList.addVirtualFiles(orderEnumerator.getSourceRoots());
         pathsList.addVirtualFiles(orderEnumerator.getClassesRoots());
+        pathsList.addVirtualFiles(orderEnumerator.getAllLibrariesAndSdkClassesRoots());
     }
 
     public void checkClientConnected(Runnable onConnected) {


### PR DESCRIPTION
In a recent commit, there was a full dispose that caused the WeavePreviewComponent not being able to be reused.  This causes plugin crash in the IDE when opening the Dataweave preview.  The proposed solution is to recreate the WeavePreviewComponent when setting a new  DWL file, because WeavePreviewComponent is always in a disposed state
at this time.

In a dataweave that has java import for classes that live in a library, the Dataweave preview complains that it cannot find the class file. The proposed solution is to send all libraries, except SDK, to the agent so that the class file is available when the script engine evaluates the Dataweave in the agent.